### PR TITLE
Bump kube-vip and kube-vip-cloud-provider version in the chart

### DIFF
--- a/charts/kube-vip-cloud-provider/Chart.yaml
+++ b/charts/kube-vip-cloud-provider/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 0.1
+appVersion: v0.0.1

--- a/charts/kube-vip-cloud-provider/values.yaml
+++ b/charts/kube-vip-cloud-provider/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: kubevip/kube-vip-cloud-provider
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: ""
+  tag: "v0.0.1"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/charts/kube-vip/Chart.yaml
+++ b/charts/kube-vip/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.7
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: v0.3.7
+appVersion: v0.4.0

--- a/charts/kube-vip/values.yaml
+++ b/charts/kube-vip/values.yaml
@@ -3,10 +3,10 @@
 # Declare variables to be passed into your templates.
 
 image:
-  repository: plndr/kube-vip
+  repository: ghcr.io/kube-vip/kube-vip
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v0.3.6"
+  tag: "v0.4.0"
 
 config:
   vip_interface: ""


### PR DESCRIPTION
Bump kube-vip chart to v0.4.0:
Switch image repository to ghcr.io/kube-vip/kube-vip
Bump kube-vip-cloud-provider chart to v0.0.1: