### PR TITLE
Remove default nodeSelector from kube-vip

### DIFF
--- a/charts/kube-vip/values.yaml
+++ b/charts/kube-vip/values.yaml
@@ -59,8 +59,8 @@ resources: { }
 #   cpu: 100m
 #   memory: 128Mi
 
-nodeSelector:
-  node-role.kubernetes.io/master: "true"
+nodeSelector: {}
+  # node-role.kubernetes.io/master: "true"
 
 tolerations:
   - effect: NoSchedule

--- a/charts/kube-vip/values.yaml
+++ b/charts/kube-vip/values.yaml
@@ -60,11 +60,10 @@ resources: { }
 #   memory: 128Mi
 
 nodeSelector: {}
-  # node-role.kubernetes.io/master: "true"
 
 tolerations:
   - effect: NoSchedule
-    key: node-role.kubernetes.io/master
+    key: node-role.kubernetes.io/control-plane
     operator: Exists
 affinity: { }
 


### PR DESCRIPTION
As this is a map, it becomes nigh impossible to unset an option that is
already set. Thanks to helm the users values get merged into the default values.