### PR TITLE
[kube-vip] Update to v0.4.1,Replace config: stanza

### DIFF
--- a/charts/kube-vip/Chart.yaml
+++ b/charts/kube-vip/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.4.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: v0.4.0
+appVersion: v0.4.1

--- a/charts/kube-vip/templates/daemonset.yaml
+++ b/charts/kube-vip/templates/daemonset.yaml
@@ -16,28 +16,18 @@ spec:
       - args:
           - manager
         env:
-          - name: vip_interface
-            value: {{ .Values.config.vip_interface | quote }}
-          {{- if eq .Values.config.cp_enable "true" }}
-          - name: vip_address
-            value: {{ required "A valid config.vip_address required!" .Values.config.vip_address}}
+          {{- if eq .Values.env.cp_enable "true" }}
+          - name: address
+            value: {{ required "A valid config.address required!" .Values.config.address}}
           {{- end }}
-          - name: vip_arp
-            value: {{ .Values.config.vip_arp | quote }}
-          - name: port
-            value: {{ .Values.config.port | quote }}
-          - name: cp_namespace
-            value: {{ .Release.Namespace }}
-          - name: vip_cidr
-            value: {{ .Values.config.vip_cidr | quote }}
-          - name: cp_enable
-            value: {{ .Values.config.cp_enable | quote }}
-          - name: svc_enable
-            value: {{ .Values.config.svc_enable | quote }}
-          - name: vip_startleader
-            value: {{ .Values.config.vip_startleader | quote }}
-          - name: vip_addpeerstolb
-            value: {{ .Values.config.vip_addpeerstolb | quote }}
+        {{- with .Values.env }}
+          {{- range $k, $v := . }}
+            {{- $name := $k }}
+            {{- $value := $v }}
+          - name: {{ quote $name }}
+            value: {{ quote $value }}
+          {{- end }}
+        {{- end }}
         image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         name: kube-vip

--- a/charts/kube-vip/values.yaml
+++ b/charts/kube-vip/values.yaml
@@ -44,7 +44,6 @@ securityContext:
     add:
       - NET_ADMIN
       - NET_RAW
-      - SYS_TIME
 
 resources: { }
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/kube-vip/values.yaml
+++ b/charts/kube-vip/values.yaml
@@ -6,21 +6,20 @@ image:
   repository: ghcr.io/kube-vip/kube-vip
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v0.4.0"
+  tag: "v0.4.1"
 
 config:
+  address: ""
+
+env:
   vip_interface: ""
-  vip_address: ""
   vip_arp: "true"
-  port: "6443"
+  lb_enable: "true"
+  lb_port: "6443"
   vip_cidr: "32"
   cp_enable: "false"
   svc_enable: "true"
-  vip_startleader: "false"
-  vip_addpeerstolb: "true"
-
-interface: ""
-address: ""
+  vip_leaderelection: "false"
 
 imagePullSecrets: [ ]
 nameOverride: ""
@@ -67,4 +66,3 @@ tolerations:
     key: node-role.kubernetes.io/master
     operator: Exists
 affinity: { }
-


### PR DESCRIPTION
Instead use a key:value loop nested under env: enabling
any of the environment variable configuration options.

Address is still kept in config.address due to validation
requirement when running the control-plane vip.