### PR TITLE
Fix template for kube-vip-cloud-provider

### DIFF
--- a/charts/kube-vip-cloud-provider/templates/statefulset.yaml
+++ b/charts/kube-vip-cloud-provider/templates/statefulset.yaml
@@ -28,14 +28,14 @@ spec:
           env:
           - name: KUBEVIP_NAMESPACE
             value: {{ .Release.Namespace | default "kube-system" | quote }}
-{{ if .Values.config.kubeVipCloudConfig }}
+          {{- if .Values.config.kubeVipCloudConfig }}
           - name: KUBEVIP_CONFIG_MAP
             value: {{ .Values.config.kubeVipCloudConfig | quote }}
-{{ end }}
-{{ if .Values.config.destinationCIDR }}
+          {{- end }}
+          {{- if .Values.config.destinationCIDR }}
           - name: KUBEVIP_SERVICE_CIDR
             value: {{ .Values.config.destinationCIDR | quote }}
-{{ end }}
+          {{- end }}
       serviceAccountName: {{ include "kube-vip-cloud-provider.name" . }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/kube-vip-cloud-provider/values.yaml
+++ b/charts/kube-vip-cloud-provider/values.yaml
@@ -54,8 +54,9 @@ tolerations: []
 
 affinity: {}
 
-# Default name of the load balancer config Map
-# kubeVipCloudConfig: "kubevip"
+config: {}
+  # Default name of the load balancer config Map
+  # kubeVipCloudConfig: "kubevip"
 
-# CIDR format IP range that this routing rule applies to.
-# destinationCIDR: "29"
+  # CIDR format IP range that this routing rule applies to.
+  # destinationCIDR: "29"


### PR DESCRIPTION
Currently, the `kube-vip-cloud-provider` helm chart does not deploy, due to an incorrect `Values` configuration. In current state, the template looks for `.Values.config.kubeVipCloudConfig`. However, the `values.yaml` file only contains `kubeVipCloudConfig` at the root, not `config.kubeVipCloudConfig`.

This causes the following failure upon deployment, since the `config` block does not exist:

```
λ › helm install --namespace kube-system kube-vip-cloud-provider kube-vip/kube-vip-cloud-provider
Error: INSTALLATION FAILED: template: kube-vip-cloud-provider/templates/statefulset.yaml:31:13: executing "kube-vip-cloud-provider/templates/statefulset.yaml" at <.Values.config.kubeVipCloudConfig>: nil pointer evaluating interface {}.kubeVipCloudConfig
```

This PR adds the `config` block to the `values.yaml` file, which fixes the issue:

```
λ › helm install --namespace kube-system kube-vip-cloud-provider .
NAME: kube-vip-cloud-provider
LAST DEPLOYED: Mon Jan 10 18:02:15 2022
NAMESPACE: kube-system
STATUS: deployed
REVISION: 1
TEST SUITE: None
```

This PR also takes the liberty of adding the `{{-` symbol to the template file to whitespace chomp. This is consistent with the rest of the file.

PR tested on helm version `3.7.2`, Go version `1.17.4`, kind version `0.11.1`.