### PR TITLE
Add ability to inject environment variables from externally provisioned secrets or configmaps

### DIFF
--- a/charts/kube-vip/Chart.yaml
+++ b/charts/kube-vip/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.2
+version: 0.4.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/kube-vip/templates/daemonset.yaml
+++ b/charts/kube-vip/templates/daemonset.yaml
@@ -28,6 +28,10 @@ spec:
             value: {{ quote $value }}
           {{- end }}
         {{- end }}
+      {{- with .Values.envFrom }}
+        envFrom:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
         image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         name: kube-vip

--- a/charts/kube-vip/values.yaml
+++ b/charts/kube-vip/values.yaml
@@ -21,6 +21,21 @@ env:
   svc_enable: "true"
   vip_leaderelection: "false"
 
+envFrom:
+  # Specify an externally created Secret(s) or ConfigMap(s) to inject environment variables
+  # For example an externally provisioned secret could contain the password for your upstream BGP router, such as
+  #
+  # apiVersion: v1
+  # data:
+  #   bgp_peers: "<address:AS:password:multihop>"
+  # kind: Secret
+  #   name: kube-vip
+  #   namespace: kube-system
+  # type: Opaque
+  #
+#- secretKeyRef:
+#    name: kube-vip
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""

--- a/charts/kube-vip/values.yaml
+++ b/charts/kube-vip/values.yaml
@@ -21,7 +21,7 @@ env:
   svc_enable: "true"
   vip_leaderelection: "false"
 
-envFrom:
+envFrom: []
   # Specify an externally created Secret(s) or ConfigMap(s) to inject environment variables
   # For example an externally provisioned secret could contain the password for your upstream BGP router, such as
   #


### PR DESCRIPTION
This PR aims to add functionality to inject externally provisioned secrets for example with the [external-secrets operator](https://external-secrets.io/).

The reason behind adding this is that of course, I don't want to push my BGP passwords to git :)