### PR TITLE
Add envValueFrom to kube-vip chart

### DIFF
--- a/charts/kube-vip/Chart.yaml
+++ b/charts/kube-vip/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.3
+version: 0.4.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/kube-vip/templates/daemonset.yaml
+++ b/charts/kube-vip/templates/daemonset.yaml
@@ -28,6 +28,15 @@ spec:
             value: {{ quote $value }}
           {{- end }}
         {{- end }}
+        {{- with .Values.envValueFrom }}
+          {{- range $k, $v := . }}
+            {{- $name := $k }}
+            {{- $value := $v }}
+          - name: {{ quote $name }}
+            valueFrom:
+              {{- toYaml $value | nindent 14 }}
+          {{- end }}
+        {{- end }}
       {{- with .Values.envFrom }}
         envFrom:
         {{- toYaml . | nindent 8 }}

--- a/charts/kube-vip/values.yaml
+++ b/charts/kube-vip/values.yaml
@@ -21,6 +21,13 @@ env:
   svc_enable: "true"
   vip_leaderelection: "false"
 
+envValueFrom: {}
+  # Specify environment variables using valueFrom references (EnvVarSource)
+  # For example we can use the IP address of the pod itself as a unique value for the routerID
+#bgp_routerid:
+#  fieldRef:
+#    fieldPath: status.podIP
+
 envFrom: []
   # Specify an externally created Secret(s) or ConfigMap(s) to inject environment variables
   # For example an externally provisioned secret could contain the password for your upstream BGP router, such as


### PR DESCRIPTION
The routerID needs to be unique on each node that participates in BGP advertisements, according to the [docs](https://kube-vip.io/docs/installation/daemonset/#managing-a-routerid-as-a-daemonset) it is recommended to use the IP address of the pod itself as a unique value for the routerID. This adds the ability to template valueFrom environment variable references in a similar manner to [other charts](https://github.com/grafana/helm-charts/blob/76c7fbe1d9ac08775bf378ad7d448d4dd8533e44/charts/grafana/values.yaml#L419).

ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#envvarsource-v1-core

Fixes #17