### PR TITLE
Fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Adding the Chart
 ```bash
-$ helm repo add kube-vip https://kube-vip.io/helm-charts
+$ helm repo add kube-vip https://kube-vip.github.io/helm-charts
 $ helm repo update
 ```
 


### PR DESCRIPTION
```
λ helm repo add kube-vip https://kube-vip.io/helm-charts                                                                                                                                                                         
Error: looks like "https://kube-vip.io/helm-charts" is not a valid chart repository or cannot be reached: failed to fetch https://kube-vip.io/helm-charts/index.yaml : 404 Not Found
```