### PR TITLE
Add the possibility of specifying extra labels

### DIFF
--- a/charts/kube-vip/templates/daemonset.yaml
+++ b/charts/kube-vip/templates/daemonset.yaml
@@ -11,6 +11,9 @@ spec:
     metadata:
       labels:
         {{- include "kube-vip.selectorLabels" . | nindent 8 }}
+      {{- with .Values.extraLabels }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       containers:
       - args:

--- a/charts/kube-vip/values.yaml
+++ b/charts/kube-vip/values.yaml
@@ -44,6 +44,9 @@ envFrom: []
   # - secretKeyRef:
   #    name: kube-vip
 
+extraLabels: {}
+  # Specify extra labels to be added to DaemonSet (and therefore to Pods)
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
In certain contexts, it may be necessary to be able to place labels on resources deployed by charts, so that ressources can be managed with other tools (monitoring for example).