### PR TITLE
Remove image tag default in cloud provider values

### DIFF
--- a/charts/kube-vip-cloud-provider/values.yaml
+++ b/charts/kube-vip-cloud-provider/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: kubevip/kube-vip-cloud-provider
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v0.0.4"
+  # tag: "v0.0.4"
 
 resources:
   requests:


### PR DESCRIPTION
Removing the default in the values to rely on the chart's AppVersion and align with `kube-vip`.