### PR TITLE
feat(kube-vip)/toBool-helper-for-cp-enable-check

### DIFF
--- a/charts/kube-vip/Chart.yaml
+++ b/charts/kube-vip/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.1
+version: 0.6.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/kube-vip/templates/_helpers.tpl
+++ b/charts/kube-vip/templates/_helpers.tpl
@@ -61,3 +61,20 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Convert string to boolean
+*/}}
+{{- define "kube-vip.toBool" -}}
+{{- if eq (lower (toString .)) "true" -}}
+{{- true -}}
+{{- else if eq (lower (toString .)) "false" -}}
+{{- false -}}
+{{- else if eq (lower (toString .)) "1" -}}
+{{- true -}}
+{{- else if eq (lower (toString .)) "0" -}}
+{{- false -}}
+{{- else -}}
+{{- default . false -}}
+{{- end -}}
+{{- end -}}

--- a/charts/kube-vip/templates/daemonset.yaml
+++ b/charts/kube-vip/templates/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
           {{- end }}
           {{- end }}
         env:
-          {{- if eq .Values.env.cp_enable "true" }}
+          {{- if eq (include "kube-vip.toBool" .Values.cp_enable) "true" }}
           - name: vip_address
             value: {{ required "A valid config.address required!" .Values.config.address}}
           {{- end }}

--- a/charts/kube-vip/templates/daemonset.yaml
+++ b/charts/kube-vip/templates/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
           {{- end }}
           {{- end }}
         env:
-          {{- if (include "kube-vip.toBool" .Values.cp_enable) }}
+          {{- if eq (include "kube-vip.toBool" .Values.env.cp_enable) "true" }}
           - name: vip_address
             value: {{ required "A valid config.address required!" .Values.config.address}}
           {{- end }}

--- a/charts/kube-vip/templates/daemonset.yaml
+++ b/charts/kube-vip/templates/daemonset.yaml
@@ -28,7 +28,7 @@ spec:
           {{- end }}
           {{- end }}
         env:
-          {{- if eq (include "kube-vip.toBool" .Values.cp_enable) "true" }}
+          {{- if (include "kube-vip.toBool" .Values.cp_enable) }}
           - name: vip_address
             value: {{ required "A valid config.address required!" .Values.config.address}}
           {{- end }}


### PR DESCRIPTION
I am writing Ansible Roles to setup k3s with different options like metallb and kube-vip.
One can choose then just by enablind certain features in the role to get a single or multo-node k3s cluster up an unning.

When using the helm-chart you have to be very precise to give the `cp_enable` as a `string` and if not, the helm install will fail with an error `"helm-controller 'error calling eq: invalid type for comparison'"`

This PR will handle that case and you will be able to give a `string`, `boolean` or `integer` to set `cp_enable`.