### PR TITLE
Add PodMonitor to Kube-Vip Helm Chart for Enhanced Metrics Collection

### DIFF
--- a/charts/kube-vip/templates/pod-monitor.yaml
+++ b/charts/kube-vip/templates/pod-monitor.yaml
@@ -1,0 +1,14 @@
+{{- if hasKey .Values.env "prometheus_server" }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "kube-vip.name" . }}
+  labels:
+    {{- include "kube-vip.selectorLabels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "kube-vip.selectorLabels" . | nindent 6 }}
+  podMetricsEndpoints:
+  - targetPort: {{ regexReplaceAll ":*" .Values.env.prometheus_server "${1}" }}
+{{- end }}


### PR DESCRIPTION
This Pull Request adds a PodMonitor resource to the Kube-Vip Helm Chart, making it easier to collect metrics from Kube-Vip pods using Prometheus. With this integration, Prometheus will automatically scrape and store the operational metrics, providing greater visibility into the performance and status of Kube-Vip within the Kubernetes cluster.

These metrics are essential for understanding how Kube-Vip is handling IP assignments and failover scenarios. By simplifying the process of metrics collection, this PodMonitor helps ensure that key performance indicators are readily available for analysis and monitoring. This enhancement supports better observability and management of Kubernetes clusters that rely on Kube-Vip for IP failover and load balancing.