### PR TITLE
Add PodMonitor to Kube-Vip Helm Chart for Enhanced Metrics Collection

### DIFF
--- a/charts/kube-vip/templates/pod-monitor.yaml
+++ b/charts/kube-vip/templates/pod-monitor.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.podMonitor.enabled (hasKey .Values.env "prometheus_server") (regexMatch "^:\\d+$" .Values.env.prometheus_server) }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "kube-vip.name" . }}
+  labels:
+    {{- include "kube-vip.selectorLabels" . | nindent 4 }}
+  {{- with .Values.podMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.podMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "kube-vip.selectorLabels" . | nindent 6 }}
+  podMetricsEndpoints:
+  - targetPort: {{ trimPrefix ":" .Values.env.prometheus_server }}
+{{- end }}

--- a/charts/kube-vip/values.yaml
+++ b/charts/kube-vip/values.yaml
@@ -104,3 +104,8 @@ affinity: {}
   #     - matchExpressions:
   #       - key: node-role.kubernetes.io/control-plane
   #         operator: Exists
+
+podMonitor:
+  enabled: false
+  labels: {}
+  annotations: {}


### PR DESCRIPTION
This Pull Request adds a PodMonitor resource to the Kube-Vip Helm Chart, making it easier to collect metrics from Kube-Vip pods using Prometheus. With this integration, Prometheus will automatically scrape and store the operational metrics, providing greater visibility into the performance and status of Kube-Vip within the Kubernetes cluster.

These metrics are essential for understanding how Kube-Vip is handling IP assignments and failover scenarios. By simplifying the process of metrics collection, this PodMonitor helps ensure that key performance indicators are readily available for analysis and monitoring. This enhancement supports better observability and management of Kubernetes clusters that rely on Kube-Vip for IP failover and load balancing.