### PR TITLE
add configurable priorityClass for kube-vip chart

### DIFF
--- a/charts/kube-vip/templates/daemonset.yaml
+++ b/charts/kube-vip/templates/daemonset.yaml
@@ -74,3 +74,6 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}

--- a/charts/kube-vip/values.yaml
+++ b/charts/kube-vip/values.yaml
@@ -104,3 +104,5 @@ affinity: {}
   #     - matchExpressions:
   #       - key: node-role.kubernetes.io/control-plane
   #         operator: Exists
+
+priorityClassName: ""


### PR DESCRIPTION
Kubernetes priorityClasses are an important mechanism to ensure important pods run promptly with the required resources, especially on heavily loaded clusters.

This adds the optional ability to set a priorityClass for the kube-vip pods.

@thebsdbox could you take a look please? Thanks!

