### PR TITLE
define minimal securityContext for cloud provider

### DIFF
--- a/charts/kube-vip-cloud-provider/templates/deployment.yaml
+++ b/charts/kube-vip-cloud-provider/templates/deployment.yaml
@@ -22,6 +22,10 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
       serviceAccountName: {{ include "kube-vip-cloud-provider.name" . }}
       {{- if .Values.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
This is required to run kube-vip-cloud-provider on clusters that enforce [Pod Security Standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/).

This just makes the seccomp profile and privilege escalation explicit to satisfy PSS requirements.
The values are defaults so this will not change the behaviour.
