### PR TITLE
update kube-vip chart

### DIFF
--- a/charts/kube-vip/Chart.yaml
+++ b/charts/kube-vip/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.2
+version: 0.6.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: "v0.8.0"
+appVersion: "v0.8.4"
 
 icon: https://github.com/kube-vip/kube-vip/raw/main/kube-vip.png
 


### PR DESCRIPTION
fix https://github.com/kube-vip/helm-charts/issues/36

This prepares a new chart version with the recent updates from other MRs that were recently merged. (Thanks!)

I tried to include a tag in this but I'm not sure if it will work.

@thebsdbox I think after merging, a maintainer will need to make a kube-vip tag to trigger the Github actions? Do you know how that works? Thanks again!