### PR TITLE
kv-cp: add configMapName value to use your own configmap

### DIFF
--- a/charts/kube-vip-cloud-provider/Chart.yaml
+++ b/charts/kube-vip-cloud-provider/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.3
+version: 0.2.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/kube-vip-cloud-provider/templates/configmap.yaml
+++ b/charts/kube-vip-cloud-provider/templates/configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "kube-vip-cloud-provider.name" . }}-cm
+  name: {{ include "kube-vip-cloud-provider.name" . }}
   namespace: {{ .Release.Namespace }}
 data:
 {{- range $key, $value := .Values.cm.data }}

--- a/charts/kube-vip-cloud-provider/templates/deployment.yaml
+++ b/charts/kube-vip-cloud-provider/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
           - name: KUBEVIP_NAMESPACE
             value: {{ .Release.Namespace }}
           - name: KUBEVIP_CONFIG_MAP
-            value: {{ include "kube-vip-cloud-provider.name" . }}-cm
+            value: {{ .Values.configMapName | default(include "kube-vip-cloud-provider.name" .) }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/kube-vip-cloud-provider/templates/deployment.yaml
+++ b/charts/kube-vip-cloud-provider/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
           - name: KUBEVIP_NAMESPACE
             value: {{ .Release.Namespace }}
           - name: KUBEVIP_CONFIG_MAP
-            value: {{ .Values.configMapName | default(include "kube-vip-cloud-provider.name" .) }}
+            value: {{ .Values.configMapName | default (include "kube-vip-cloud-provider.name" .) }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/kube-vip-cloud-provider/values.yaml
+++ b/charts/kube-vip-cloud-provider/values.yaml
@@ -24,6 +24,10 @@ image:
 cm:
   data: {}
 
+# By default, kube-vip-cloud-provider will use a configMap automatically generated from .Values.cm.data.
+# If .Values.configMapName is defined, it will use that configMap instead, which you must create yourself.
+configMapName: ""
+
 resources:
   requests:
     cpu: 50m


### PR DESCRIPTION
This adds on to https://github.com/kube-vip/helm-charts/pull/48 and allows custom configmaps of IP pools to be used, which you can create and manage yourself.


- add .Values.configMapName, if defined your own custom configmap will be used
- cosmetic change to configmap name for templating simplicity , no functional impact
