### PR TITLE
try to fix chart releaser CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,3 +61,4 @@ jobs:
         uses: helm/chart-releaser-action@v1.2.1
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_SKIP_EXISTING: "true"


### PR DESCRIPTION
Fix https://github.com/kube-vip/helm-charts/issues/51  (hopefully!)

The errors shown here: https://github.com/kube-vip/helm-charts/issues/51#issuecomment-2438396918
are the same as described in https://github.com/helm/chart-releaser/issues/101 , with the reported solution of using the `--skip-existing` flag or CR_SKIP_EXISTING env var.

This MR adds that env var, which is documented here: https://github.com/helm/chart-releaser?tab=readme-ov-file#common-error-messages

FYI @thebsdbox 
