### PR TITLE
feat(kube-vip): add support for volumes and hostaliases configuration

### DIFF
--- a/charts/kube-vip/Chart.yaml
+++ b/charts/kube-vip/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.3
+version: 0.6.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/kube-vip/templates/daemonset.yaml
+++ b/charts/kube-vip/templates/daemonset.yaml
@@ -60,6 +60,14 @@ spec:
           {{- toYaml .Values.resources | nindent 10 }}
         securityContext:
           {{- toYaml .Values.securityContext | nindent 10 }}
+        {{- with .Values.volumeMounts }}
+        volumeMounts:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      {{- with .Values.hostAliases }}
+      hostAliases:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       hostNetwork: true
       serviceAccountName: {{ include "kube-vip.name" . }}
       {{- with .Values.nodeSelector }}
@@ -68,6 +76,10 @@ spec:
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.volumes }}
+      volumes:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.affinity }}

--- a/charts/kube-vip/values.yaml
+++ b/charts/kube-vip/values.yaml
@@ -88,6 +88,24 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
+volumes: []
+  # Specify additional volumes
+  #   - hostPath:
+  #       path: /etc/rancher/k3s/k3s.yaml
+  #       type: File
+  #     name: kubeconfig
+
+volumeMounts: []
+  # Specify additional volume mounts
+  # - mountPath: /etc/kubernetes/admin.conf
+  #   name: kubeconfig
+
+hostAliases: []
+  # Specify additional host aliases
+  # - hostnames:
+  #     - kubernetes
+  #   ip: 127.0.0.1
+
 nodeSelector: {}
 
 tolerations:


### PR DESCRIPTION
Add support to set additional volumes, volumeMounts and hostAliases.

I'm using KubeVIP with K3S and I need to pass the kubeconfig into the container and define 127.0.0.1 as kubernetes host aliases.

```
volumes:
  - hostPath:
     path: /etc/rancher/k3s/k3s.yaml
     type: File
     name: kubeconfig
     
volumeMounts:
  - mountPath: /etc/kubernetes/admin.conf
    name: kubeconfig

hostAliases:
  - hostnames:
      - kubernetes
    ip: 127.0.0.1
```
