### PR TITLE
Add namespaceOverride template variable

### DIFF
--- a/charts/kube-vip-cloud-provider/templates/_helpers.tpl
+++ b/charts/kube-vip-cloud-provider/templates/_helpers.tpl
@@ -7,6 +7,17 @@ Expand the name of the chart.
 {{- end }}
 
 {{/*
+Determine the namespace to use, allowing for a namespace override.
+*/}}
+{{- define "kube-vip-cloudprovider.namespace" -}}
+  {{- if .Values.namespaceOverride }}
+    {{- .Values.namespaceOverride }}
+  {{- else }}
+    {{- .Release.Namespace }}
+  {{- end }}
+{{- end }}
+
+{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.

--- a/charts/kube-vip-cloud-provider/templates/configmap.yaml
+++ b/charts/kube-vip-cloud-provider/templates/configmap.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "kube-vip-cloud-provider.name" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "kube-vip-cloudprovider.namespace" . }}
 data:
 {{- range $key, $value := .Values.cm.data }}
   {{ $key }}: {{ $value | quote }}

--- a/charts/kube-vip-cloud-provider/templates/deployment.yaml
+++ b/charts/kube-vip-cloud-provider/templates/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "kube-vip-cloud-provider.name" . }}
-  namespace: {{ .Release.Namespace | default "kube-system" }}
+  namespace: {{ include "kube-vip-cloudprovider.namespace" . | default "kube-system" }}
 spec:
   replicas: {{ .Values.replicasCount }}
   selector:

--- a/charts/kube-vip-cloud-provider/templates/rbac.yaml
+++ b/charts/kube-vip-cloud-provider/templates/rbac.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "kube-vip-cloud-provider.name" . }}
-  namespace: {{ .Release.Namespace | default "kube-system" }}
+  namespace: {{ include "kube-vip-cloudprovider.namespace" . | default "kube-system" }}
   labels:
   {{- include "kube-vip-cloud-provider.labels" . | nindent 4 }}
 ---
@@ -34,4 +34,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "kube-vip-cloud-provider.name" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ include "kube-vip-cloudprovider.namespace" . }}

--- a/charts/kube-vip-cloud-provider/values.yaml
+++ b/charts/kube-vip-cloud-provider/values.yaml
@@ -10,6 +10,9 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   # tag: "v0.0.4"
 
+# Custom namespace to override the namespace for the deployed resources.
+namespaceOverride: ""
+
 ## Cloud Provider ConfigMap
 ## CIDR blocks , IP ranges [start address - end address]
 ## Multiple pools by CIDR per Namespace, Multiple IP ranges per Namespace (handles overlapping ranges)

--- a/charts/kube-vip/templates/_helpers.tpl
+++ b/charts/kube-vip/templates/_helpers.tpl
@@ -25,6 +25,17 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 
 {{/*
+Determine the namespace to use, allowing for a namespace override.
+*/}}
+{{- define "kube-vip.namespace" -}}
+  {{- if .Values.namespaceOverride }}
+    {{- .Values.namespaceOverride }}
+  {{- else }}
+    {{- .Release.Namespace }}
+  {{- end }}
+{{- end }}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "kube-vip.chart" -}}

--- a/charts/kube-vip/templates/daemonset.yaml
+++ b/charts/kube-vip/templates/daemonset.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ include "kube-vip.name" . }}
-  namespace: {{ .Release.Namespace | default "kube-system" }}
+  namespace: {{ include "kube-vip.namespace" . | default "kube-system" }}
 spec:
   selector:
     matchLabels:

--- a/charts/kube-vip/templates/rbac.yaml
+++ b/charts/kube-vip/templates/rbac.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "kube-vip.name" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "kube-vip.namespace" . }}
   labels:
   {{- include "kube-vip.labels" . | nindent 4 }}
 ---
@@ -33,4 +33,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ include "kube-vip.name" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "kube-vip.namespace" . }}

--- a/charts/kube-vip/values.yaml
+++ b/charts/kube-vip/values.yaml
@@ -55,6 +55,8 @@ extraLabels: {}
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
+# Custom namespace to override the namespace for the deployed resources.
+namespaceOverride: ""
 
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
Added namespaceOverride template variable to support flexible namespace configurations.
Introduced helper function in helpers.tpl for namespace resolution.

I opened this PR as I created a single helm chart to bootstrap my k8s cluster. Without this change I need to either switch to the namespace `kube-system` before doing the `helm install...` or I have to pass the namespace via `helm upgrade -- install --namespace`. 
As my bootstrapping is happening in different namespaces I would like to avoid both of the options named above and use the variable in the `values.yaml`