### PR TITLE
Drop capabilities

### DIFF
--- a/charts/kube-vip/Chart.yaml
+++ b/charts/kube-vip/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.4
+version: 0.6.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/kube-vip/values.yaml
+++ b/charts/kube-vip/values.yaml
@@ -75,6 +75,8 @@ securityContext:
     add:
       - NET_ADMIN
       - NET_RAW
+    drop:
+      - ALL
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
This addresses the helm chart part of https://github.com/kube-vip/kube-vip/issues/1010

This works on a test cluster AFAICT.

It can be overridden by setting `.Values.securityContext.capabilities.drop: null`