### PR TITLE
PodMonitor: use port instead of targetPort

### DIFF
--- a/charts/kube-vip/templates/daemonset.yaml
+++ b/charts/kube-vip/templates/daemonset.yaml
@@ -27,6 +27,12 @@ spec:
           {{- end }}
           {{- end }}
           {{- end }}
+        {{- if and .Values.podMonitor.enabled (hasKey .Values.env "prometheus_server") (regexMatch "^:\\d+$" .Values.env.prometheus_server) }}
+        ports:
+        - containerPort: {{ trimPrefix ":" .Values.env.prometheus_server }}
+          name: monitoring
+          protocol: TCP
+        {{- end }}
         env:
           {{- if eq (include "kube-vip.toBool" .Values.env.cp_enable) "true" }}
           - name: vip_address

--- a/charts/kube-vip/templates/pod-monitor.yaml
+++ b/charts/kube-vip/templates/pod-monitor.yaml
@@ -17,5 +17,5 @@ spec:
     matchLabels:
       {{- include "kube-vip.selectorLabels" . | nindent 6 }}
   podMetricsEndpoints:
-  - targetPort: {{ trimPrefix ":" .Values.env.prometheus_server }}
+  - port: monitoring
 {{- end }}

--- a/charts/kube-vip/values.yaml
+++ b/charts/kube-vip/values.yaml
@@ -21,6 +21,7 @@ env:
   svc_enable: "true"
   svc_election: "false"
   vip_leaderelection: "false"
+  # prometheus_server: ":2112"
 
 extraArgs: {}
   # Specify additional arguments to kube-vip


### PR DESCRIPTION
According to https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.PodMetricsEndpoint, the targetPort field of the PodMonitor CRD is deprecated.
With the current release, the Prometheus fails to scrape pods with "No active targets".

This PR changes targetPort to port in the PodMonitor spec and declares a container port in the Daemonset spec as the port field of PodMonitor requires a port name.