### PR TITLE
Add ability to enable loadbalancerClass on cloud provider

### DIFF
--- a/charts/kube-vip-cloud-provider/templates/deployment.yaml
+++ b/charts/kube-vip-cloud-provider/templates/deployment.yaml
@@ -24,6 +24,10 @@ spec:
             value: {{ .Release.Namespace }}
           - name: KUBEVIP_CONFIG_MAP
             value: {{ .Values.configMapName | default (include "kube-vip-cloud-provider.name" .) }}
+          {{- if .Values.enableloadbalancerClass }}
+          - name: KUBEVIP_ENABLE_LOADBALANCERCLASS
+            value: "true"
+          {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/kube-vip-cloud-provider/values.yaml
+++ b/charts/kube-vip-cloud-provider/values.yaml
@@ -71,3 +71,7 @@ affinity:
               operator: Exists
 
 priorityClassName: ""
+
+# Enable loadbalancerClass to only reconcile services that have
+# spec.loadbalancerClass: kube-vip.io/kube-vip-class
+enableloadbalancerClass: false


### PR DESCRIPTION
 kube-vip-cloud-provider [supports loadbalancerClass](https://github.com/kube-vip/kube-vip-cloud-provider/pull/100) by adding environment variable `KUBEVIP_ENABLE_LOADBALANCERCLASS: true` 
 
 This PR provides the ability to set this variable when installing cloud provider using the helm chart.

