### PR TITLE
Allow configurable annotations for deployment

### DIFF
--- a/charts/kube-vip-cloud-provider/Chart.yaml
+++ b/charts/kube-vip-cloud-provider/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.5
+version: 0.2.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/kube-vip-cloud-provider/templates/deployment.yaml
+++ b/charts/kube-vip-cloud-provider/templates/deployment.yaml
@@ -3,6 +3,10 @@ kind: Deployment
 metadata:
   name: {{ include "kube-vip-cloud-provider.name" . }}
   namespace: {{ include "kube-vip-cloudprovider.namespace" . | default "kube-system" }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicasCount }}
   selector:

--- a/charts/kube-vip-cloud-provider/values.yaml
+++ b/charts/kube-vip-cloud-provider/values.yaml
@@ -31,6 +31,8 @@ cm:
 # If .Values.configMapName is defined, it will use that configMap instead, which you must create yourself.
 configMapName: ""
 
+annotations: {}
+
 resources:
   requests:
     cpu: 50m


### PR DESCRIPTION
A particular application of annotations is to use <https://github.com/stakater/Reloader> to restart the deployment automatically when the underlying ConfigMap has been changed.