### PR TITLE
Add patch as verb to the RBAC

### DIFF
--- a/charts/kube-vip/templates/rbac.yaml
+++ b/charts/kube-vip/templates/rbac.yaml
@@ -15,7 +15,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["services", "services/status", "nodes", "endpoints"]
-    verbs: ["list","get","watch", "update"]
+    verbs: ["list","get","watch", "update", "patch"]
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["list", "get", "watch", "update", "create"]


### PR DESCRIPTION
Patch is also required for patching the nodes with the  ```kube-vip.io/has-ip``` label