### PR TITLE
fix helm repo add

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Adding the Chart
 ```bash
-$ helm repo add kube-vip https://kube-vip.io/helm-charts
+$ helm repo add kube-vip https://kube-vip.github.io/helm-charts
 $ helm repo update
 ```
 


### PR DESCRIPTION
Behind https://kube-vip.io/helm-charts is a 301 redirect and helm is not able to follow it. One has to use use the GitHub pages URL directly.