### PR TITLE
misleading env var name updated

### DIFF
--- a/charts/kube-vip/values.yaml
+++ b/charts/kube-vip/values.yaml
@@ -16,7 +16,7 @@ env:
   vip_arp: "true"
   lb_enable: "true"
   lb_port: "6443"
-  vip_cidr: "32"
+  vip_subnet: "32"
   cp_enable: "false"
   svc_enable: "true"
   svc_election: "false"


### PR DESCRIPTION
`vpc_cidr` is misleading here (as potentially changed at some point in time) and took a little while finding it out. 