### PR TITLE
update chart versions to 0.9.1

### DIFF
--- a/charts/kube-vip/Chart.yaml
+++ b/charts/kube-vip/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.6
+version: 0.7.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: "v0.8.9"
+appVersion: "v0.9.1"
 
 icon: https://github.com/kube-vip/kube-vip/raw/main/kube-vip.png
 

--- a/charts/kube-vip/values.yaml
+++ b/charts/kube-vip/values.yaml
@@ -16,7 +16,7 @@ env:
   vip_arp: "true"
   lb_enable: "true"
   lb_port: "6443"
-  vip_cidr: "32"
+  vip_subnet: "32"
   cp_enable: "false"
   svc_enable: "true"
   svc_election: "false"


### PR DESCRIPTION
This PR bumps the appVersion and chart version to latest, and applies the breaking change in 0.9.0 to values.yaml.

I'm not entirely sure why appVersion and chart version are not synced, seems they were identical until 0.4.1. Happy to update this PR to make them match if required.

First time using commit signing, apologies!