### PR TITLE
Add imagePullSecrets

### DIFF
--- a/charts/kube-vip-cloud-provider/templates/deployment.yaml
+++ b/charts/kube-vip-cloud-provider/templates/deployment.yaml
@@ -37,6 +37,10 @@ spec:
             runAsGroup: 65532
             seccompProfile:
               type: RuntimeDefault
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "kube-vip-cloud-provider.name" . }}
       {{- if .Values.nodeSelector }}
       nodeSelector:

--- a/charts/kube-vip-cloud-provider/values.yaml
+++ b/charts/kube-vip-cloud-provider/values.yaml
@@ -10,6 +10,8 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   # tag: "v0.0.4"
 
+imagePullSecrets: []
+
 # Custom namespace to override the namespace for the deployed resources.
 namespaceOverride: ""
 

--- a/charts/kube-vip/templates/daemonset.yaml
+++ b/charts/kube-vip/templates/daemonset.yaml
@@ -74,6 +74,10 @@ spec:
       hostAliases:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       hostNetwork: true
       serviceAccountName: {{ include "kube-vip.name" . }}
       {{- with .Values.nodeSelector }}


### PR DESCRIPTION
This PR adds ability to define `imagePullSecrets` for both `kube-vip` and `kube-vip-cloud-provider` to support pulling images from private registries, which require authentication.