### PR TITLE
fix prometheus_server lint errors

### DIFF
--- a/charts/kube-vip/Chart.yaml
+++ b/charts/kube-vip/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.0
+version: 0.8.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/kube-vip/templates/daemonset.yaml
+++ b/charts/kube-vip/templates/daemonset.yaml
@@ -27,7 +27,7 @@ spec:
           {{- end }}
           {{- end }}
           {{- end }}
-        {{- if and .Values.podMonitor.enabled (hasKey .Values.env "prometheus_server") (regexMatch "^:\\d+$" .Values.env.prometheus_server) }}
+        {{- if and .Values.podMonitor.enabled (regexMatch "^:\\d+$" .Values.env.prometheus_server) }}
         ports:
         - containerPort: {{ trimPrefix ":" .Values.env.prometheus_server }}
           name: monitoring

--- a/charts/kube-vip/templates/pod-monitor.yaml
+++ b/charts/kube-vip/templates/pod-monitor.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.podMonitor.enabled (hasKey .Values.env "prometheus_server") (regexMatch "^:\\d+$" .Values.env.prometheus_server) }}
+{{- if .Values.podMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:

--- a/charts/kube-vip/values.yaml
+++ b/charts/kube-vip/values.yaml
@@ -21,7 +21,7 @@ env:
   svc_enable: "true"
   svc_election: "false"
   vip_leaderelection: "false"
-  # prometheus_server: ":2112"
+  prometheus_server: ":2112"
 
 extraArgs: {}
   # Specify additional arguments to kube-vip


### PR DESCRIPTION

- Define the default value of `prometheus_server` as a real Helm default value, to fix lint errors introduced by https://github.com/kube-vip/helm-charts/pull/42 and noted in https://github.com/kube-vip/helm-charts/pull/80. I confirmed that this does not cause a change of behaviour - kube-vip listens on :2112 by default whether or not the prometheus_server env var is set (to :2112).
  -  Side note and my .02:  the value of a Helm chart is in abstracting details. In other words, a user should be able to install and configure the Helm chart and easily see what the values are, without having to _necessarily_ [dig a layer deeper](https://github.com/kube-vip/kube-vip/blob/0889ebed7d49afd219126eca98ffabca3e7effd3/cmd/kube-vip.go#L136) to find all the kube-vip binary command-line options and defaults.
- The podMonitor and containerPort were already conditional on `.Values.podMonitor.enabled` , so now that the prometheus_server env var is always defined by default, those conditions can be simplified.

