### PR TITLE
Chart 0.9.0 for kube-vip 1.0.0

### DIFF
--- a/charts/kube-vip/Chart.yaml
+++ b/charts/kube-vip/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.2
+version: 0.9.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: "v0.9.2"
+appVersion: "v1.0.0"
 
 icon: https://github.com/kube-vip/kube-vip/raw/main/kube-vip.png
 


### PR DESCRIPTION
Fix https://github.com/kube-vip/helm-charts/issues/85

Update to kube-vip v1.0.0, see https://github.com/kube-vip/kube-vip/releases/tag/v1.0.0

Note the new capability in kube-vip 1.0.0 to set rp_filter via an annotation is not yet supported in the Helm chart:
https://github.com/kube-vip/helm-charts/issues/81