### PR TITLE
fix kube-vip podSecurityContext (chart 0.9.2)

### DIFF
--- a/charts/kube-vip/Chart.yaml
+++ b/charts/kube-vip/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.1
+version: 0.9.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/kube-vip/templates/daemonset.yaml
+++ b/charts/kube-vip/templates/daemonset.yaml
@@ -80,6 +80,10 @@ spec:
       {{- end }}
       hostNetwork: true
       serviceAccountName: {{ include "kube-vip.name" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
Fis podSecurityContext variable not being applied in kube-vip helm-chart, fix this issue: https://github.com/kube-vip/helm-charts/issues/92