### PR TITLE
fix: add podAnnotations in kube-vip deamonSet

### DIFF
--- a/charts/kube-vip/templates/daemonset.yaml
+++ b/charts/kube-vip/templates/daemonset.yaml
@@ -14,6 +14,10 @@ spec:
       {{- with .Values.extraLabels }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       containers:
       - args:


### PR DESCRIPTION
Add support for podAnnotations in the kube-vip DaemonSet.

The podAnnotations value was already defined in values.yaml but not used in the DaemonSet template.