### PR TITLE
add secret list/get capabilities to role (0.9.8)

### DIFF
--- a/charts/kube-vip/Chart.yaml
+++ b/charts/kube-vip/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.7
+version: 0.9.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/kube-vip/templates/rbac.yaml
+++ b/charts/kube-vip/templates/rbac.yaml
@@ -31,6 +31,9 @@ rules:
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["list"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["list", "get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/kube-vip/templates/rbac.yaml
+++ b/charts/kube-vip/templates/rbac.yaml
@@ -31,9 +31,6 @@ rules:
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["list"]
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["list", "get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -44,6 +41,34 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
+  name: {{ include "kube-vip.name" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "kube-vip.name" . }}
+  namespace: {{ include "kube-vip.namespace" . }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "kube-vip.name" . }}
+  namespace: {{ include "kube-vip.namespace" . }}
+  labels:
+  {{- include "kube-vip.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["list", "get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "kube-vip.name" . }}
+  namespace: {{ include "kube-vip.namespace" . }}
+  labels:
+  {{- include "kube-vip.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
   name: {{ include "kube-vip.name" . }}
 subjects:
 - kind: ServiceAccount


### PR DESCRIPTION
This PR adds the secret list/get capabilities to the kube-vip clusterrole. The [WireGuard implementation](https://kube-vip.io/docs/usage/wireguard/) needs this, as the tunnels are stored inside a secret. Needed for https://github.com/kube-vip/kube-vip/issues/1381