### PR TITLE
fix: Adding annotations to DaemonSet metadata (chart 0.9.9)

### DIFF
--- a/charts/kube-vip/Chart.yaml
+++ b/charts/kube-vip/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.8
+version: 0.9.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/kube-vip/templates/daemonset.yaml
+++ b/charts/kube-vip/templates/daemonset.yaml
@@ -3,6 +3,10 @@ kind: DaemonSet
 metadata:
   name: {{ include "kube-vip.name" . }}
   namespace: {{ include "kube-vip.namespace" . | default "kube-system" }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels:

--- a/charts/kube-vip/values.yaml
+++ b/charts/kube-vip/values.yaml
@@ -53,6 +53,9 @@ envFrom: []
 extraLabels: {}
   # Specify extra labels to be added to DaemonSet (and therefore to Pods)
 
+annotations: {}
+  # Specify annotations to be added to DaemonSet
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
Adding support for `metadata.annotations` in daemonset.yaml

Signed-off-by: Shubham Pai lifeofpai94@gmail.com