### PR TITLE
fix: add support for pod annotations in kube-vip daemonset (chart 0.9.10)

### DIFF
--- a/charts/kube-vip/Chart.yaml
+++ b/charts/kube-vip/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.9
+version: 0.9.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/kube-vip/templates/daemonset.yaml
+++ b/charts/kube-vip/templates/daemonset.yaml
@@ -22,6 +22,10 @@ spec:
       {{- with .Values.extraLabels }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       containers:
       - args:


### PR DESCRIPTION
The podAnnotations value is already present in values.yaml

This PR replaces #99