### PR TITLE
kube-vip: update to v1.1.2 (chart 0.10.0)

### DIFF
--- a/charts/kube-vip/Chart.yaml
+++ b/charts/kube-vip/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.10
+version: 0.10.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: "v1.0.4"
+appVersion: "v1.1.2"
 
 icon: https://github.com/kube-vip/kube-vip/raw/main/kube-vip.png
 


### PR DESCRIPTION
Update from kube-vip v1.0.4 to v1.1.2:
- https://github.com/kube-vip/kube-vip/releases/tag/v1.1.0
- https://github.com/kube-vip/kube-vip/releases/tag/v1.1.1
- https://github.com/kube-vip/kube-vip/releases/tag/v1.1.2