### PR TITLE
update CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,64 +1,55 @@
 name: Lint, Test and Release charts
-
 on:
   pull_request:
   push:
-
 jobs:
   lint-test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - run: |
           git remote add upstream https://github.com/kube-vip/helm-charts.git
           git fetch upstream
       - name: Set up Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v4
         with:
           version: v3.4.0
-
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
-          python-version: '3.8' 
-
+          python-version: '3.12'
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.1.0
-
+        uses: helm/chart-testing-action@v2.8.0
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
           changed=$(ct list-changed --config tests/ct.yaml)
           if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
       - name: Run chart-testing (lint-master)
         run: ct lint --check-version-increment=false --config tests/ct.yaml
       - name: Create kind cluster
-        uses: helm/kind-action@v1.2.0
+        uses: helm/kind-action@v1.12.0
         if: steps.list-changed.outputs.changed == 'true'
-
       - name: Run chart-testing (install)
         run: ct install --config tests/ct.yaml
-
   release:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/heads/main')
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
-
       - name: Configure Git
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.2.1
+        uses: helm/chart-releaser-action@v1.7.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_SKIP_EXISTING: "true"


### PR DESCRIPTION
Update some action versions to address a deprecation:  https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

and others just to keep them up-to-date. 
(I'm not sure which specific versions should be used; this was suggested by Claude.)